### PR TITLE
condor: Remove already defined attribute

### DIFF
--- a/sepolicy/device.te
+++ b/sepolicy/device.te
@@ -3,5 +3,4 @@ type cid_block_device, dev_type;
 type clogo_block_device, dev_type;
 type logs_block_device, dev_type;
 type hob_block_device, dev_type;
-type userdata_block_device, dev_type;
 type utags_block_device, dev_type;


### PR DESCRIPTION
type userdata_block_device, dev_type; is defined with https://github.com/CyanogenMod/android_external_sepolicy/commit/887d7afedb01248f05f55b3064ad84d6076eca03

Build error:

device/motorola/condor/sepolicy/device.te:7:ERROR 'duplicate declaration of type/attribute' at token ';' on line 17835:
type hob_block_device, dev_type;
type userdata_block_device, dev_type;
checkpolicy:  error(s) encountered while parsing configuration

Change-Id: I0d8a90ee94e41af716ad67ea97311b30cb796255